### PR TITLE
Fixed MapProtect Bypass.

### DIFF
--- a/src/main/java/dev/corestone/lotrings/abilities/TunnelingAbility.java
+++ b/src/main/java/dev/corestone/lotrings/abilities/TunnelingAbility.java
@@ -42,9 +42,10 @@ public class TunnelingAbility extends AbilitySuper {
         }
     }
 
-    @EventHandler(priority = EventPriority.LOW)
-    public void PlayerRightClick(BlockBreakEvent event) {
+    @EventHandler(priority = EventPriority.HIGH)
+    public void PlayerBreakBlock(BlockBreakEvent event) {
         if(isBreaking)return;
+        if(event.isCancelled())return;
         if (!abilityCanBeUsed(event.getPlayer().getUniqueId())) return;
         //if (cooldownManager.checkAndStartCooldown()) return;
 


### PR DESCRIPTION
Event Priorities are really confusing. Reference #7. This properly stopped MapProtect from being bypassed. Note that I did not test this myself because I am on my Chromebook, but this should work. The usage in #7 is tested and functions properly.